### PR TITLE
Griky - Corona - Failure to Create Resources

### DIFF
--- a/externality/static/js/src/externality.js
+++ b/externality/static/js/src/externality.js
@@ -1,42 +1,39 @@
-//$(document).ready(
-$(document).on("hover", ".supported-tags-nav > li",
-    function ExternalContentXBlock(runtime, element) {
-        $(function ($) {
-            /* Here's where you'd do things on page load. */
-        });
+ function ExternalContentXBlock(runtime, element) {
+    $(function ($) {
+        /* Here's where you'd do things on page load. */
+    });
 
-        window.onload = function() {
-            setTimeout(function() {
-                var data = {
-                    'completion': 1.0,
-                };
-                var handlerUrl = runtime.handlerUrl(element, 'publish_completion');
+    window.onload = function() {
+        setTimeout(function() {
+            var data = {
+                'completion': 1.0,
+            };
+            var handlerUrl = runtime.handlerUrl(element, 'publish_completion');
 
-                $.post(handlerUrl, JSON.stringify(data)).complete(function() {});
-            }, 1000);
+            $.post(handlerUrl, JSON.stringify(data)).complete(function() {});
+        }, 1000);
 
-        };
+    };
 
-        function updateResList(activeTab) {
-            var $resources = $(".supported-resources li.resource-item");
-            var activeStatus = activeTab;
+    function updateResList(activeTab) {
+        var $resources = $(".supported-resources li.resource-item");
+        var activeStatus = activeTab;
 
-            $resources.each(function () {
-                if (activeStatus == 'all-tags' || $(this).data('status').split(',').includes(activeStatus) ) {
-                    $(this).show();
-                } else {
-                    $(this).hide();
-                }
-            })
-
-        }
-
-        $('.supported-tags-nav > li', element).bind('click', function() {
-            $(this).find('.btn-link').addClass('active-section');
-            $(this).siblings().find('.btn-link').removeClass('active-section');
-            updateResList($(this).attr('id'));
-
-        });
+        $resources.each(function () {
+            if (activeStatus == 'all-tags' || $(this).data('status').split(',').includes(activeStatus) ) {
+                $(this).show();
+            } else {
+                $(this).hide();
+            }
+        })
 
     }
-)
+
+    $('.supported-tags-nav > li', element).bind('click', function() {
+        $(this).find('.btn-link').addClass('active-section');
+        $(this).siblings().find('.btn-link').removeClass('active-section');
+        updateResList($(this).attr('id'));
+
+    });
+
+}

--- a/externality/static/js/src/externality.js
+++ b/externality/static/js/src/externality.js
@@ -3,17 +3,21 @@
         /* Here's where you'd do things on page load. */
     });
 
-    window.onload = function() {
-        setTimeout(function() {
-            var data = {
-                'completion': 1.0,
-            };
-            var handlerUrl = runtime.handlerUrl(element, 'publish_completion');
+    if ($('.externalityxblock_block').length > 0) {
+        // In LMS page, we mark as completed for this user.
+        window.onload = function () {
+            setTimeout(function () {
+                var data = {
+                    'completion': 1.0,
+                };
+                var handlerUrl = runtime.handlerUrl(element, 'publish_completion');
 
-            $.post(handlerUrl, JSON.stringify(data)).complete(function() {});
-        }, 1000);
+                $.post(handlerUrl, JSON.stringify(data)).complete(function () {
+                });
+            }, 1000);
 
-    };
+        };
+    }
 
     function updateResList(activeTab) {
         var $resources = $(".supported-resources li.resource-item");


### PR DESCRIPTION
# Task
 - https://innso.atlassian.net/browse/TRIB-530

# How to reproduce this issue mentioned in Ticket
 - Create an instance of `External Web Content` in Studio
 - Then create an instance of `Blank Quiz` below `External Web Content` in Studio
 - Then we got same issue as follow :
![image](https://github.com/Learningtribes/external-content-xblock/assets/26813045/f3875e9a-204f-4992-ba73-c3d7e1ce2d66)

# Reason
 - Because we got exception while loading `External Web Content` 
```
window['ExternalContentXBlock']
undefined
```

# Tested in devstack
![image](https://github.com/Learningtribes/external-content-xblock/assets/26813045/f0e38143-286e-4cad-a0f0-645818a3929d)
![image](https://github.com/Learningtribes/external-content-xblock/assets/26813045/1a528037-944b-45a1-b828-066109c65201)

![image](https://github.com/Learningtribes/external-content-xblock/assets/26813045/bb093f57-e094-4d27-9821-cdb8868d4f84)
![image](https://github.com/Learningtribes/external-content-xblock/assets/26813045/a9cbd795-8187-4df6-902b-72da5b38f952)

# Tested on STAGING
 - Course URL ( https://studio-stage2.learning-tribes.com.cn/container/block-v1:edX+bcs_101_a+bcs_2021_a+type@vertical+block@e540e06ff0a9448b8eae0956b2c61301?action=new ) 👇  
![image](https://github.com/Learningtribes/external-content-xblock/assets/26813045/6b044100-ff92-4a7a-8636-2542a4ec15ef)
 - Applied the new code 
![image](https://github.com/Learningtribes/external-content-xblock/assets/26813045/1e39ab4d-fd5b-4f1b-a413-97974fa91cc0)
![image](https://github.com/Learningtribes/external-content-xblock/assets/26813045/fde43787-3c71-4611-b9cf-82a2b7809ce1)



